### PR TITLE
fix peer dependency error with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "next-fonts": "^0.17.0",
     "next-images": "^1.1.1",
     "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react-dom": "^16.8.6",
+    "react-router-dom": "^5.0.1"
   }
 }


### PR DESCRIPTION
When using npm there is a peer dependency error for react-router-dom which brings an internal server error when you start nextjs.

Added react-router-dom to package.json.